### PR TITLE
Add missing parentTag

### DIFF
--- a/src/HTML.js
+++ b/src/HTML.js
@@ -280,6 +280,7 @@ export default class HTML extends PureComponent {
                     data: data.replace(/(\r\n|\n|\r)/gm, ''), // remove linebreaks
                     attribs: attribs || {},
                     parent,
+                    parentTag: parent && parent.name,
                     tagName: name || 'rawtext'
                 };
             }


### PR DESCRIPTION
In `filterBaseFontStyles` function, every element was missing a `parentTag` property, hence some styles (font styles), were not applied, when used `tagsStyles` prop.